### PR TITLE
fix: Use simulated opaque values for `TreeAdapterTypeMap`

### DIFF
--- a/packages/htmlparser2-tree-adapter/lib/index.ts
+++ b/packages/htmlparser2-tree-adapter/lib/index.ts
@@ -16,16 +16,16 @@ import {
 export { isComment as isCommentNode, isTag as isElementNode, isText as isTextNode } from 'domhandler';
 
 export type Htmlparser2TreeAdapterMap = TreeAdapterTypeMap<
-    Node,
-    NodeWithChildren,
-    Node,
     Document,
     Document,
     Element,
     Comment,
     Text,
     Element,
-    ProcessingInstruction
+    ProcessingInstruction,
+    Node,
+    NodeWithChildren,
+    Node
 >;
 
 //Node construction

--- a/packages/parse5/lib/tree-adapters/default.ts
+++ b/packages/parse5/lib/tree-adapters/default.ts
@@ -97,16 +97,16 @@ export type ChildNode = Element | Template | CommentNode | TextNode | DocumentTy
 export type Node = ParentNode | ChildNode;
 
 export type DefaultTreeAdapterMap = TreeAdapterTypeMap<
-    Node,
-    ParentNode,
-    ChildNode,
     Document,
     DocumentFragment,
     Element,
     CommentNode,
     TextNode,
     Template,
-    DocumentType
+    DocumentType,
+    ParentNode,
+    ChildNode,
+    Node
 >;
 
 //Node construction

--- a/packages/parse5/lib/tree-adapters/interface.ts
+++ b/packages/parse5/lib/tree-adapters/interface.ts
@@ -1,21 +1,37 @@
 import { DOCUMENT_MODE, NAMESPACES } from '../common/html.js';
 import type { Attribute, ElementLocation } from '../common/token.js';
 
+/**
+ * A unique symbol that doesn't actually exist,
+ * to help with creating opaque types for the type map.
+ *
+ * This way, we will never have colliding keys with the
+ * default values of the tree map.
+ */
+declare const adapterKey: unique symbol;
+
+/**
+ * All the node types.
+ *
+ * The default values should be opaque types. TS doesn't support opaque types,
+ * so we use unique objects instead.
+ *
+ * The unions below include `Record<string, unknown>`, to make it impossible
+ * to get a type through narrowing. This way, DOMs can have additional node types
+ * that aren't listed here.
+ */
 export interface TreeAdapterTypeMap<
-    Node = unknown,
-    ParentNode = unknown,
-    ChildNode = unknown,
-    Document = unknown,
-    DocumentFragment = unknown,
-    Element = unknown,
-    CommentNode = unknown,
-    TextNode = unknown,
-    Template = unknown,
-    DocumentType = unknown
+    Document = { [adapterKey]?: 'Document' },
+    DocumentFragment = { [adapterKey]?: 'DocumentFragment' },
+    Element = { [adapterKey]?: 'Element' },
+    CommentNode = { [adapterKey]?: 'CommentNode' },
+    TextNode = { [adapterKey]?: 'TextNode' },
+    Template = { [adapterKey]?: 'Template' },
+    DocumentType = { [adapterKey]?: 'DocumentType' },
+    ParentNode = Document | DocumentFragment | Element | Template | Record<string, unknown>,
+    ChildNode = Element | Template | CommentNode | TextNode | DocumentType | Record<string, unknown>,
+    Node = ParentNode | ChildNode
 > {
-    node: Node;
-    parentNode: ParentNode;
-    childNode: ChildNode;
     document: Document;
     documentFragment: DocumentFragment;
     element: Element;
@@ -23,6 +39,9 @@ export interface TreeAdapterTypeMap<
     textNode: TextNode;
     template: Template;
     documentType: DocumentType;
+    parentNode: ParentNode;
+    childNode: ChildNode;
+    node: Node;
 }
 
 /**

--- a/packages/parse5/lib/tree-adapters/interface.ts
+++ b/packages/parse5/lib/tree-adapters/interface.ts
@@ -14,7 +14,8 @@ declare const adapterKey: unique symbol;
  * All the node types.
  *
  * The default values should be opaque types. TS doesn't support opaque types,
- * so we use unique objects instead.
+ * so we use unique objects instead. Their one key is optional, so adapters
+ * can assign any kind of object they want to.
  *
  * The unions below include `Record<string, unknown>`, to make it impossible
  * to get a type through narrowing. This way, DOMs can have additional node types


### PR DESCRIPTION
Opening this to have a base of discussion for https://github.com/parse5/parse5-fork/discussions/38.

This produces all of the expected type errors — see the failing tests.